### PR TITLE
add statusline function

### DIFF
--- a/autoload/lessmess.vim
+++ b/autoload/lessmess.vim
@@ -69,6 +69,18 @@ el
     let s:contains_empty_lines = 0
     let s:contains_mixed_indent = 0
     let s:contains_trailing_whitespaces = 0
+    "
+    " Initialise statusline symbols
+    let s:symbols = {
+                \   'empty': 'empty',
+                \   'mixed_indent': 'mixed-indent',
+                \   'trailing': 'trailing',
+                \}
+    if exists("g:lessmess_symbols")
+        for [k, v] in items(g:lessmess_symbols)
+            let s:symbols[k] = v
+        endfor
+    en
 en
 " }}}
 
@@ -354,6 +366,22 @@ fun! lessmess#LessmessStatus()
     el
         retu 'OFF'
     en
+endf
+"
+" Return a statusline
+"
+fun! lessmess#statusline()
+    let elements = []
+    if s:contains_empty_lines > 0
+        let elements = elements + [s:symbols.empty . ':' . s:contains_empty_lines]
+    en
+    if s:contains_mixed_indent > 0
+        let elements = elements + [s:symbols.mixed_indent . ':' . s:contains_mixed_indent]
+    en
+    if s:contains_trailing_whitespaces > 0
+        let elements = elements + [s:symbols.trailing . ':' . s:contains_trailing_whitespaces]
+    en
+    return join(elements, ' ')
 endf
 " }}}
 

--- a/doc/lessmess.txt
+++ b/doc/lessmess.txt
@@ -84,8 +84,34 @@ configuration needs to be added
 let g:confirm_whitespace_removal = 1
 
 ==============================================================================
-3. Configuration~
+4. Configuration~
 
 To disable LessmessExecute on write make sure to include the configuration
 below in your vimrc. The setting is enabled by default.
 let g:enable_lessmess_onsave = 0
+
+==============================================================================
+5. Statusline~
+                                                    *lessmess#statusline()*
+Add %{lessmess#statusline()} to your statusline to get an indicator of the
+mess within the current file. It will notify you as to when there are:
+whitespaces, mixed identation or empty lines. If you don't have a statusline,
+this one matches the default when 'ruler' is set:
+>
+    set statusline=%<%f\ %h%m%r%{lessmess#statusline()}%=%-14.(%l,%c%V%)\ %P
+<
+
+The *g:lessmess_symbols* option
+
+The symbols in the statusline may be tweaked with the this option.
+
+Default: "{'empty' : 'empty',
+         \ 'mixed_indent': 'mixed-indent',
+         \ 'trailing': 'trailing'}"
+>
+  let g:lessmess_symbols = {
+        \ 'empty' : 'empty',
+        \ 'mixed_indent' : 'mixed-indent',
+        \ 'trailing' : 'trailing',
+        \}
+<


### PR DESCRIPTION
Adds a statusline function so that the status of a files 'mess' can be tracked. It also adds some new global variables so that symbols in the statusline can be changed.

Probably not suitable for a direct merge, I assume you will have some thoughts on this or even feel there is no need for it.

![screen shot 2018-04-20 at 13 42 06](https://user-images.githubusercontent.com/2750747/39051469-a4a5de94-44a0-11e8-94ee-c2eba3efc1c8.png)
